### PR TITLE
Remove outdated config import error

### DIFF
--- a/src/codeql_vul.py
+++ b/src/codeql_vul.py
@@ -19,11 +19,8 @@ THIS_SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 NEUROSYMSA_ROOT_DIR = os.path.abspath(f"{THIS_SCRIPT_DIR}/../../")
 sys.path.append(NEUROSYMSA_ROOT_DIR)
 
-try:
-    from src.config import CODEQL_DIR, CODEQL_DB_PATH, OUTPUT_DIR, ALL_METHOD_INFO_DIR, PROJECT_SOURCE_CODE_DIR, CVES_MAPPED_W_COMMITS_DIR
-except:
-    print("[ERROR] Configuration file (config.py) not found. Under strategies directory, do\n\n\tcp config_template.py config.py\n\nand modify the content of config.py")
-    exit(1)
+from src.config import CODEQL_DIR, CODEQL_DB_PATH, OUTPUT_DIR, ALL_METHOD_INFO_DIR, PROJECT_SOURCE_CODE_DIR, CVES_MAPPED_W_COMMITS_DIR
+
 
 from src.logger import Logger
 from src.queries import QUERIES

--- a/src/codeql_vul_for_query.py
+++ b/src/codeql_vul_for_query.py
@@ -8,11 +8,8 @@ THIS_SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 NEUROSYMSA_ROOT_DIR = os.path.abspath(f"{THIS_SCRIPT_DIR}/../../")
 sys.path.append(NEUROSYMSA_ROOT_DIR)
 
-try:
-    from src.config import CVES_MAPPED_W_COMMITS_DIR, CVE_REPO_TAGS_DIR
-except:
-    print("[ERROR] Configuration file (config.py) not found. Under strategies directory, do\n\n\tcp config_template.py config.py\n\nand modify the content of config.py")
-    exit(1)
+from src.config import CVES_MAPPED_W_COMMITS_DIR, CVE_REPO_TAGS_DIR
+
 
 from src.queries import QUERIES
 

--- a/src/neusym_vul.py
+++ b/src/neusym_vul.py
@@ -19,11 +19,8 @@ THIS_SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 NEUROSYMSA_ROOT_DIR = os.path.abspath(f"{THIS_SCRIPT_DIR}/../")
 sys.path.append(NEUROSYMSA_ROOT_DIR)
 
-try:
-    from src.config import CODEQL_DIR, CODEQL_DB_PATH, PACKAGE_MODULES_PATH, OUTPUT_DIR, ALL_METHOD_INFO_DIR, PROJECT_SOURCE_CODE_DIR, CVES_MAPPED_W_COMMITS_DIR
-except:
-    print("[ERROR] Configuration file (config.py) not found. Under strategies directory, do\n\n\tcp config_template.py config.py\n\nand modify the content of config.py")
-    exit(1)
+from src.config import CODEQL_DIR, CODEQL_DB_PATH, PACKAGE_MODULES_PATH, OUTPUT_DIR, ALL_METHOD_INFO_DIR, PROJECT_SOURCE_CODE_DIR, CVES_MAPPED_W_COMMITS_DIR
+
 
 from src.logger import Logger
 from src.queries import QUERIES

--- a/src/neusym_vul_for_query.py
+++ b/src/neusym_vul_for_query.py
@@ -8,12 +8,7 @@ THIS_SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 NEUROSYMSA_ROOT_DIR = os.path.abspath(f"{THIS_SCRIPT_DIR}/../")
 sys.path.append(NEUROSYMSA_ROOT_DIR)
 
-try:
-    from src.config import CVES_MAPPED_W_COMMITS_DIR
-except:
-    print("[ERROR] Configuration file (config.py) not found. Under strategies directory, do\n\n\tcp config_template.py config.py\n\nand modify the content of config.py")
-    exit(1)
-
+from src.config import CVES_MAPPED_W_COMMITS_DIR
 from src.queries import QUERIES
 
 def collect_projects_for_query(query, cwe_id, all_cves_with_commit, all_project_tags):


### PR DESCRIPTION
Error message is related to an outdated way of managing configuration for IRIS. Not relevant; remove. 