### PR TITLE
add script to get internal packages for a new java project

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,15 +202,25 @@ The easiest way to run IRIS on a Java project not in CWE-Bench-Java is to make t
 1. Add the project info to `data/cwe-bench-java/data/project_info.csv`. For instance, to run the latest perwendel/spark version:
 
 ```
-ID,perwendel__spark_latest,,CWE-022,,perwendel,spark,latest,,,,
+ID,perwendel__spark_latest,,,,,perwendel,spark,latest,,,,
 ```
 
-The only required fields are: project slug (use a unique name), cwe_id, github username, and github tag if any.
+The only required fields are: project slug (use a unique name), github username, and github tag if any.
 
 2. Clone the project to `data/cwe-bench-java/project-sources`. Use the same folder name as the slug used above.
 3. Add build info to `data/cwe-bench-java/data/build_info.csv`. For instance, you can add: `perwendel__spark_latest,success,8u202,3.5.0,n/a,n/a` to use java 8 and mvn 3.5.0. Please use appropriate java/mvn/gradle versions as needed.
-4. Provide a list of internal packages in `data/cwe-bench-java/package-names/[slug].txt`. This should contain the package names of all internal packages of the project. E.g., `spark` for `perwendel/spark`.
-5. Follow the steps 3, 4, and quickstart steps in the installation section.
+4. Build the Java project.
+```bash
+$ python3 data/cwe-bench-java/scripts/setup.py --filter [project slug]
+```
+5. Generate the CodeQL database.
+```bash
+$ python3 scripts/build_codeql_dbs.py --project [project slug]
+```
+6. Provide a list of internal packages in `data/cwe-bench-java/package-names/[slug].txt`. This should contain the package names of all internal packages of the project. E.g., `spark` for `perwendel/spark`. The following command uses CodeQL to extract the internal packages and writes them to the required txt file in the `package-names` directory. We provided a script to automate this. 
+```bash
+$ python scripts/get_packages_codeql.py [project slug]
+```
 
 
 

--- a/scripts/get_packages_codeql.py
+++ b/scripts/get_packages_codeql.py
@@ -1,0 +1,85 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+def create_codeql_query(query_path):
+    query = """
+/**
+ * @name Find All Packages
+ * @description Lists all packages in the Java project
+ * @kind table
+ * @id java/all-packages
+ */
+ import java
+ 
+ from Package p
+ select p.getName() as name
+    """.strip()
+    
+    with open(query_path, 'w') as f:
+        f.write(query)
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: python get_packages_codeql.py <project_name>")
+        sys.exit(1)
+
+    project_name = sys.argv[1]
+    iris_root = Path(__file__).parent.parent
+    output_file = iris_root / "data" / "cwe-bench-java" / "package-names" / f"{project_name}.txt"
+    query_path = iris_root / "scripts" / "packages.ql"
+    db_path = iris_root / "data" / "codeql-dbs" / project_name
+     
+    # Create query file
+    create_codeql_query(query_path)
+    
+    try:
+        print(f"Running get internal packages query on {project_name}...")
+        
+        # Run codeql query directly with bqrs output
+        result = subprocess.run(
+            ["codeql", "query", "run", "--database", str(db_path), 
+             "--output=results.bqrs", str(query_path)],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        
+        print("\nQuery completed. Getting results...")
+        
+        result = subprocess.run(
+            ["codeql", "bqrs", "decode", "--format=csv", "results.bqrs"],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        
+        print("Raw output:")
+        print(result.stdout)
+        
+        package_names = set()
+        for line in result.stdout.strip().split('\n')[1:]: 
+            if line.strip():
+                package_names.add(line.strip().strip('"'))
+        
+        package_names = sorted(package_names)
+        with open(output_file, 'w') as f:
+            for package in package_names:
+                f.write(f"{package}\n")
+        
+        print(f"\nFound {len(package_names)} packages. Results written to {output_file}")
+        
+    except subprocess.CalledProcessError as e:
+        print(f"Error running CodeQL command: {e}")
+        if e.stderr:
+            print(f"Error output: {e.stderr}")
+    finally:
+        # Clean up temporary files
+        if query_path.exists():
+            query_path.unlink()
+        if Path("results.bqrs").exists():
+            Path("results.bqrs").unlink()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #15

The script generates a codeql query to get the internal package names. Also updated readme instructions for adding a new java project.