### PR TITLE
Fix setup environment script to be consistent with src/config.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Run `scripts/setup_environment.sh`.
 ```bash
 $ chmod +x scripts/setup_environment.sh
 $ bash ./scripts/setup_environment.sh
+$ source ~/.bashrc # make sure to source .bashrc for PATH update
 ```
 This will do the following:
 - creates a conda environment specified by environment.yml
@@ -108,6 +109,11 @@ $ python3 scripts/build_codeql_dbs.py
 # build a specific CodeQL database given the project slug
 $ python3 scripts/build_codeql_dbs.py --project perwendel__spark_CVE-2018-9159_2.7.1 
 ```
+Note - if the script fails due to trying to locate CodeQL, run the following to find the path:
+```bash
+$ which codeql
+```
+Then update `CODEQL_DIR` in `src/config.py`. 
 
 ### Step 4. Check IRIS directory configuration in `src/config.py`
 By running the provided scripts, you won't have to modify `src/config.py`. Double check that the paths in the configuration are correct. Each path variable has a comment explaining its purpose.
@@ -429,8 +435,3 @@ IRIS is a collaborative effort between researchers at the University of Pennsylv
 <img src="https://github.com/user-attachments/assets/37969a67-a3fd-4b4f-9be4-dfeed28d2b48" width="175" height="175" alt="Cornell University" />
 
 <img src="https://github.com/user-attachments/assets/362abdfb-4ca4-46b2-b003-b185ce4d20af" width="300" height="200" alt="University of Pennsylvania"/>
-
-
-
-
-

--- a/scripts/setup_environment.sh
+++ b/scripts/setup_environment.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# IMPORTANT: This script is designed to be executed from the 'iris-dev' root directory.
+# To run: ./scripts/setup_environment.sh
+
 # Exit on error
 set -e
 
@@ -26,7 +29,7 @@ conda env create -f environment.yml
 
 # Create necessary directories
 echo "Creating directories..."
-PROJECT_ROOT=$(cd ".." && pwd)
+PROJECT_ROOT=$(pwd)
 CODEQL_DIR="$PROJECT_ROOT/codeql"
 mkdir -p "$CODEQL_DIR"
 mkdir -p "$PROJECT_ROOT/data/codeql-dbs"
@@ -40,12 +43,18 @@ if ! curl -L -o "$CODEQL_ZIP" "$CODEQL_URL"; then
 fi
 
 echo "Extracting CodeQL..."
-if ! unzip -qo "$CODEQL_ZIP" -d "$CODEQL_DIR"; then
+TEMP_DIR="$PROJECT_ROOT/temp_codeql_extract"
+mkdir -p "$TEMP_DIR"
+
+if ! unzip -qo "$CODEQL_ZIP" -d "$TEMP_DIR"; then
     echo "Error: Failed to extract CodeQL"
     rm -f "$CODEQL_ZIP"
+    rm -rf "$TEMP_DIR"
     exit 1
 fi
 
+mv "$TEMP_DIR/codeql"/* "$CODEQL_DIR"
+rm -rf "$TEMP_DIR"
 rm -f "$CODEQL_ZIP"
 
 CODEQL_BIN="$CODEQL_DIR/codeql"


### PR DESCRIPTION
Fixed the environment script to ensure codeql binary gets installed in iris project root path, and the path is consistent with the default defined `CODEQL_DIR` variable in `src/config.py`. Added more instructions in README to ensure this consistency. 