### PR TITLE
Fix jdk-17 references in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,14 +39,14 @@ RUN ENV_NAME=$(head -1 environment.yml | cut -d' ' -f2) && \
     echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
     echo "conda activate $ENV_NAME" >> ~/.bashrc
 # Copy JDKs from build context
-COPY jdk-7u80-linux-x64.tar.gz jdk-8u202-linux-x64.tar.gz jdk-17.0.12_linux-x64_bin.tar.gz /iris/data/cwe-bench-java/java-env/
+COPY jdk-7u80-linux-x64.tar.gz jdk-8u202-linux-x64.tar.gz jdk-17_linux-x64_bin.tar.gz /iris/data/cwe-bench-java/java-env/
 RUN cd /iris/data/cwe-bench-java/java-env/ && \
     tar xzf jdk-8u202-linux-x64.tar.gz --no-same-owner && \
     tar xzf jdk-7u80-linux-x64.tar.gz --no-same-owner && \
-    tar xzf jdk-17.0.12_linux-x64_bin.tar.gz --no-same-owner && \
+    tar xzf jdk-17_linux-x64_bin.tar.gz --no-same-owner && \
     chmod -R 755 */bin */lib && \
     chmod -R 755 */jre/bin */jre/lib && \
     rm *.tar.gz && \
-    ls -la jdk-17.0.12/lib/libjli.so  # Verify the library exists and permissions
+    ls -la jdk-17/lib/libjli.so  # Verify the library exists and permissions
 RUN rm -rf /iris/*.tar.gz
 CMD ["/bin/bash"]


### PR DESCRIPTION
fixes #28

Was able to reproduce error reported in #28. I specified jdk-17.0.2 instead of jdk-17 leading to the issue. Was able to correctly build dockerfile with this fix. 