### PR TITLE
Include contextual analysis hint in docs for adding a CWE

### DIFF
--- a/docs/adding_cwes.md
+++ b/docs/adding_cwes.md
@@ -49,7 +49,7 @@ Also add the following imports:
 
 Remove the former predicate definitions and anything else in the file related to the former predicates. Now in the `.ql` file, update the imports to refer to the renamed `.qll` module.
 
-5. Now within the `queries.py` file, add the CWE and its queries to the `QUERIES` dictionary. Note - if the CWE is double digits - for the id use 0[number]. For example - CWE 22 would be `cwe-022`. Use the following format - we use CWE-22 as an example:
+5. Now within the [`queries.py`](../src/queries.py) file, add the CWE and its queries to the `QUERIES` dictionary. Note - if the CWE is double digits - for the id use 0[number]. For example - CWE 22 would be `cwe-022`. Use the following format - we use CWE-22 as an example:
 ```
 "cwe-[number]wLLM": {
     "name": "cwe-[number]wLLM",
@@ -116,4 +116,6 @@ For the `long_desc` key - look up definitions of the CWE and find a clear descri
 
 For the examples, you will need to provide sources and sinks. A CodeQL source is a value that an attacker can use for malicious operations within a system. A CodeQL sink is a program point that accepts a malicious source, and ends up using the malicious data. You can use the [Github Advisory Database](https://github.com/advisories) to find examples of the CWE. Or the definition may provide common abstractions which you can then search for Java's most used libraries for the related abstraction. 
 
-6. After adding to the `queries.py` file - test out the query. You can provide the --test-run parameter when running `neusym_vul.py` to see if the CodeQL queries compile. Afterwards, you can try a test run with a small model on one of the Java projects. 
+6. Add a hint related to CWE for contextual analysis prompt in [`prompts.py`](../src/prompts.py). Hints are stored in `POSTHOC_FILTER_HINTS`. The key should be the CWE number and the value include sentences that describe extra details to look out for when detecting the CWE. Sites that have definitions for the CWE will often have more specific guidance on the CWE.
+
+6. Test out the query. You can provide the --test-run parameter when running `neusym_vul.py` to see if the CodeQL queries compile. Afterwards, you can try a test run with a small model on one of the Java projects associated with the CWE. The [GitHub Advisory Database](https://github.com/advisories) is an easy way to find a vulnerable project given the CWE.

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -122,7 +122,8 @@ Sink ({sink_msg}):
 
 {context}\
 """
-
+# The key should be the CWE number without any string prefixes. 
+# The value should be sentences describing more specific details for detecting the CWE. 
 POSTHOC_FILTER_HINTS = {
     "022": "Note: please be careful about defensing against absolute paths and \"..\" paths. Just canonicalizing paths might not be sufficient for the defense.",
     "078": "Note that other than typical Runtime.exec which is directly executing command, using Java Reflection to create dynamic objects with unsanitized inputs might also cause OS Command injection vulnerability. This includes deserializing objects from untrusted strings and similar functionalities. Writing to config files about library data may also induce unwanted execution of OS commands.",


### PR DESCRIPTION
Forgot to include the step of adding a hint for the CWE, for the contextual analysis prompt. This would be the final step in adding a new CWE.