### PR TITLE
Adding Gemini Support

### DIFF
--- a/src/models/gemini.py
+++ b/src/models/gemini.py
@@ -18,7 +18,6 @@ _GEMINI_DEFAULT_PARAMS = {"temperature": 0.4, "top_p": 1, "top_k": 32, "max_toke
 
 class GeminiModel(LLM):
     def __init__(self, model_name, logger: MyLogger, **kwargs):
-        super().__init__(model_name, logger, _model_name_map, **kwargs)
         # https://aistudio.google.com/app/apikey
         if ("google_api_key" in kwargs) and (kwargs["google_api_key"] is not None):
             api_key = kwargs["google_api_key"]

--- a/src/models/llm.py
+++ b/src/models/llm.py
@@ -246,6 +246,11 @@ class LLM:
         elif model_name.lower().startswith("qwen"):
             from models.qwen import QwenModel
             model=QwenModel(model_name=model_name, logger=logger, **kwargs)
+
+        elif model_name.lower().startswith("gemini"):
+            from models.gemini import GeminiModel
+            model=GeminiModel(model_name=model_name, logger=logger, **kwargs)
+
         else:
             logger.log(model_name + " not implemented")
             exit(1)


### PR DESCRIPTION
Added Google Gemini option to `llm.py`. Commented out the call to `super().__init__()` in `GeminiModel` to skip Hugging Face model/tokenizer loading, as Gemini models are accessed via the `google-generativeai` API.