### PR TITLE
Fix Resolve 404 errors when running visualizer/server.py from absolute paths

### DIFF
--- a/visualizer/server.py
+++ b/visualizer/server.py
@@ -84,9 +84,11 @@ if not CONFIG:
         "api": {"base_url": "http://localhost:8000/api"}
     }
 
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 class IRISVisualizerHandler(http.server.SimpleHTTPRequestHandler):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, directory=os.getcwd(), **kwargs)
+        server_root = os.path.dirname(os.path.abspath(__file__))
+        super().__init__(*args, directory=server_root, **kwargs)
     
     def do_GET(self):
         """Handle GET requests"""
@@ -123,7 +125,7 @@ class IRISVisualizerHandler(http.server.SimpleHTTPRequestHandler):
         
         # Read and send file content
         try:
-            file_path = os.path.join(os.getcwd(), path.lstrip('/'))
+            file_path = os.path.join(BASE_DIR, path.lstrip('/'))
             if os.path.exists(file_path):
                 with open(file_path, 'rb') as f:
                     self.wfile.write(f.read())


### PR DESCRIPTION
Hi

### Problem
When launching `visualizer/server.py` from the project root or any absolute path, the server failed to locate static files and returned 404 errors. This was due to the use of `os.getcwd()` when resolving file paths, which depends on the current working directory rather than the script's location.

### Changes
Replaced `os.getcwd()` with `BASE_DIR` derived from `__file__` to make all paths relative to the script location
Explicitly set `directory` parameter in `SimpleHTTPRequestHandler` to avoid CWD-dependent behavior
