### PR TITLE
Fix CWE queries for 295, 611, and 352

### DIFF
--- a/src/cwe-queries/cwe-295/MyInsecureTrustManagerQuery.qll
+++ b/src/cwe-queries/cwe-295/MyInsecureTrustManagerQuery.qll
@@ -5,6 +5,8 @@ import semmle.code.java.dataflow.FlowSources
 import MyInsecureTrustManager
 import MySources
 import MySinks
+import MySummaries
+
 
 /**
  * A configuration to model the flow of an insecure `TrustManager`
@@ -13,15 +15,17 @@ import MySinks
 module MyInsecureTrustManagerConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { 
     //source instanceof InsecureTrustManagerSource 
-    isGPTDetectedSourceMethod(source.asExpr().(MethodCall).getMethod())
-}
+    isGPTDetectedSource(source)
+  }
 
   predicate isSink(DataFlow::Node sink) { 
     //sink instanceof InsecureTrustManagerSink 
-    (isGPTDetectedSinkMethodCall(sink.asExpr().(Call)) or
-    isGPTDetectedSinkArgument(sink.asExpr().(Argument)) )
-    and not isGuardedByInsecureFlag(this)
-}
+    isGPTDetectedSink(sink)
+  }
+
+  predicate isAdditionalFlowStep(DataFlow::Node n1, DataFlow::Node n2) {
+    isGPTDetectedStep(n1, n2)
+  }
 
   predicate allowImplicitRead(DataFlow::Node node, DataFlow::ContentSet c) {
     (isSink(node) or isAdditionalFlowStep(node, _)) and

--- a/src/cwe-queries/cwe-611/MyXxeRemoteQuery.qll
+++ b/src/cwe-queries/cwe-611/MyXxeRemoteQuery.qll
@@ -6,30 +6,28 @@ private import semmle.code.java.dataflow.TaintTracking
 private import MyXxeQuery
 import MySources 
 import MySinks
+import MySummaries
 
 /**
  * A taint-tracking configuration for unvalidated remote user input that is used in XML external entity expansion.
  */
 module MyXxeConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node src) {
+  predicate isSource(DataFlow::Node source) {
      //src instanceof ThreatModelFlowSource
-     isGPTDetectedSourceMethod(source.asExpr().(MethodCall).getMethod()) 
-    }
+     isGPTDetectedSource(source)
+  }
 
   predicate isSink(DataFlow::Node sink) { 
     //sink instanceof XxeSink 
-    isGPTDetectedSinkMethodCall(sink.asExpr().(Call)) or
- 
-    // an argument to a method call
-    isGPTDetectedSinkArgument(sink.asExpr().(Argument))
-}
+    isGPTDetectedSink(sink)
+  }
 
   predicate isBarrier(DataFlow::Node sanitizer) { 
     sanitizer instanceof XxeSanitizer 
-}
+  }
 
   predicate isAdditionalFlowStep(DataFlow::Node n1, DataFlow::Node n2) {
-    any(XxeAdditionalTaintStep s).step(n1, n2)
+    isGPTDetectedStep(n1, n2)
   }
 }
 

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -133,7 +133,9 @@ POSTHOC_FILTER_HINTS = {
     "918": "Server-Side Request Forgery occurs when untrusted input controls the target of an outgoing HTTP or other protocol request. Watch for user input flowing into URL constructors, HTTP client execute/connect methods, or SSRF-related libraries without validation.",
     "502": "Be cautious of calls to deserialization methods like `readObject()` or `deserialize()` when passed data from untrusted sources. Attackers may craft malicious object graphs or gadget chains to trigger unexpected behavior or even remote code execution. Check if class allowlisting or validation is in place. Avoid deserializing directly from network input or unvalidated byte arrays.",
     "807": "Pay special attention to cases where user-controlled input is directly used in permission checks (e.g., permission strings or resource identifiers). Focus on whether permission checks (such as Subject.isPermitted or similar APIs) rely on tainted or untrusted data, which may allow privilege escalation or unauthorized access.",
-    "352": "Check if the JSONP callback parameter is validated or restricted. Unchecked callback parameters may allow attackers to inject arbitrary JavaScript, leading to CSRF or data theft."
+    "352": "Check if the JSONP callback parameter is validated or restricted. Unchecked callback parameters may allow attackers to inject arbitrary JavaScript, leading to CSRF or data theft.",
+    "611": "Check if a default entity resolver is enabled, and if there is a Document Type Definition (DTD). The DTD may include arbitrary HTTP requests that the server may execute. Be careful with deserialization of XML-derived objects.",
+    "295": "If certificate pinning is being used, ensure that all relevant properties of the certificate are fully validated before the certificate is pinned, including the hostname. Always verify the full certificate chain."
 }
 
 SNIPPET_CONTEXT_SIZE = 4

--- a/src/queries.py
+++ b/src/queries.py
@@ -635,7 +635,7 @@ CWE-807 refers that the product uses a protection mechanism that relies on the e
   "queries": [
     "cwe-queries/cwe-352/cwe-352wLLM.ql",
     "cwe-queries/cwe-352/MyJsonpInjectionLib.qll",
-"cwe-queries/cwe-352/MyJsonStringLib.qll",
+    "cwe-queries/cwe-352/MyJsonStringLib.qll",
   ],
   "prompts": {
     "cwe_id": "CWE-352",
@@ -672,7 +672,83 @@ Sources typically include untrusted HTTP request parameters (such as 'callback')
     ]
   }
 },
-
+"cwe-611wLLM": {
+    "name": "cwe-611wLLM",
+    "type": "cwe-query",
+    "cwe_id": "611",
+    "cwe_id_short": "611",
+    "cwe_id_tag": "CWE-611",
+    "desc": "Improper Restriction of XML External Entity Reference",
+    "queries": [
+      "cwe-queries/cwe-611/XXE.ql",
+      "cwe-queries/cwe-611/MyXxeRemoteQuery.qll",
+      "cwe-queries/cwe-611/MyXxeQuery.qll",
+      "cwe-queries/cwe-611/MyXxe.qll"
+    ],
+    "prompts": {
+      "cwe_id": "CWE-611",
+      "desc": "Improper Restriction of XML External Entity Reference",
+      "long_desc": """\
+        XML documents optionally contain a Document Type Definition (DTD), which, among other features, enables the definition of XML entities. It is possible to define an entity by providing a substitution string in the form of a URI. The XML parser can access the contents of this URI and embed these contents back into the XML document for further processing. \
+By submitting an XML file that defines an external entity with a file:// URI, an attacker can cause the processing application to read the contents of a local file. For example, a URI such as "file:///c:/winnt/win.ini" designates (in Windows) the file C:\Winnt\win.ini, or file:///etc/passwd designates the password file in Unix-based systems. Using URIs with other schemes such as http://, the attacker can force the application to make outgoing requests to servers that the attacker cannot reach directly, which can be used to bypass firewall restrictions or hide the source of attacks such as port scanning.\
+Once the content of the URI is read, it is fed back into the application that is processing the XML. This application may echo back the data (e.g. in an error message), thereby exposing the file contents.""",
+      "examples": [ 
+        {
+          "package": "javax.xml.transform",
+          "class": "DefaultDDFFileValidator",
+          "method": "validate",
+          "signature": "void validate(Source xmlToValidate)",
+          "sink_args": [],
+          "type": "source"
+        },
+        {
+          "package": "java.xml.parsers.DocumentBuilderFactory",
+          "class": "DOMWalker",
+          "method": "",
+          "signature": "Object readObject()",
+          "sink_args": [],
+          "type": "sink"
+        }, 
+      ]
+    }
+  },
+  "cwe-295wLLM": {
+    "name": "cwe-295wLLM",
+    "type": "cwe-query",
+    "cwe_id": "295",
+    "cwe_id_short": "295",
+    "cwe_id_tag": "CWE-295",
+    "desc": "Improper Certificate Validation",
+    "queries": [
+      "cwe-queries/cwe-295/InsecureTrustManager.ql",
+      "cwe-queries/cwe-295/MyInsecureTrustManager.qll",
+      "cwe-queries/cwe-295/MyInsecureTrustManagerQuery.qll",
+    ],
+    "prompts": {
+      "cwe_id": "CWE-295",
+      "desc": "Improper Certificate Validation",
+      "long_desc": """\
+      When a certificate is invalid or malicious, it might allow an attacker to spoof a trusted entity by interfering in the communication path between the host and client. The product might connect to a malicious host while believing it is a trusted host, or the product might be deceived into accepting spoofed data that appears to originate from a trusted host.""",
+      "examples": [ 
+        {
+          "package": "org.keycloak.authentication.AuthenticationFlowContext",
+          "class": "ValidateX509CertificateUsername",
+          "method": "authenticate",
+          "signature": "void authenticate(AuthenticationFlowContext context)",
+          "sink_args": [],
+          "type": "source"
+        },
+        {
+          "package": "com.tigervnc.rfb",
+          "class": "CSecurityTLS",
+          "method": "checkServerTrusted",
+          "signature": "checkServerTrusted(X509Certificate[] chain, String authType)",
+          "sink_args": ["chain", "authType"],
+          "type": "sink"
+        }, 
+      ]
+    }
+  },
 
   "fetch_external_apis": {
     "name": "fetch_external_apis",


### PR DESCRIPTION
- Edits CWE queries for CWE-295, CWE-611, and CWE-352 to use LLM predicates.
- Adds posthoc filter prompts in ```prompts.py``` for CWE-611 and CWE-295
- Adds entries in ```queries.py``` for CWE-611 and CWE-295.